### PR TITLE
Earlier PlayerCheck

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
@@ -124,10 +124,10 @@ if CLIENT then
 		local unchangedEnt = tData:GetUnchangedEntity()
 		local ent = tData:GetEntity()
 
-		if not IsValid(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
-
 		-- has to be a player
-		if not ent:IsPlayer() then return end
+		if not IsPlayer(ent) then return end
+
+		if not IsValid(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
 
 		-- add title and subtitle to the focused ent
 		local h_string, h_color = util.HealthToString(unchangedEnt:Health(), unchangedEnt:GetMaxHealth())


### PR DESCRIPTION
This should solve #7 
By moving the player check upwards, we make sure, that the newly introduced plymeta-functions are actually available.