### PR TITLE
Add player check

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
@@ -127,7 +127,7 @@ if CLIENT then
 		-- has to be a player
 		if not IsPlayer(ent) then return end
 
-		if not IsValid(unchangedEnt) or IsPlayer(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
+		if not IsValid(unchangedEnt) or not IsPlayer(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
 
 		-- add title and subtitle to the focused ent
 		local h_string, h_color = util.HealthToString(unchangedEnt:Health(), unchangedEnt:GetMaxHealth())

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_identity_disguiser.lua
@@ -127,7 +127,7 @@ if CLIENT then
 		-- has to be a player
 		if not IsPlayer(ent) then return end
 
-		if not IsValid(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
+		if not IsValid(unchangedEnt) or IsPlayer(unchangedEnt) or unchangedEnt:GetDisguiserTarget() ~= ent then return end
 
 		-- add title and subtitle to the focused ent
 		local h_string, h_color = util.HealthToString(unchangedEnt:Health(), unchangedEnt:GetMaxHealth())


### PR DESCRIPTION
unchangedEnt still needs to be a player even if the new entity is a player.
As the TTTModifyTargetedEntity Hook could be used in combination with altering the view of the client.

This will once published on the workshop close #7 
Tested this with the new TTT2 Workshop release and the demonicsheep without extra disguiser functions.